### PR TITLE
We've found in ruby 1.9 we're getting sporadicly stalled SSH connections

### DIFF
--- a/lib/net/ssh/gateway.rb
+++ b/lib/net/ssh/gateway.rb
@@ -190,7 +190,7 @@ class Net::SSH::Gateway
       @thread = Thread.new do
         while @active
           @session_mutex.synchronize do
-            @session.process(0.1)
+            @session.process(0.001)
           end
           Thread.pass
         end


### PR DESCRIPTION
We've found in ruby 1.9 we're getting sporadicly stalled SSH connections. It looks like Net::SSH is waiting for openssh and openssh is waiting for Net::SSH. When we decreased the wait time for process we were able to succesfully use capistrano's gateway feature again.

This may actually be a bug in Net::SSH Session#process (we are using 2.1.3) but this resolves the issue for us.
