### PR TITLE
Move the removal of loop_wait from options above net::ssh start so that ...

### DIFF
--- a/lib/net/ssh/gateway.rb
+++ b/lib/net/ssh/gateway.rb
@@ -71,11 +71,11 @@ class Net::SSH::Gateway
   # with the :loop_wait option.
   #
   def initialize(host, user, options={})
+    @loop_wait = options.delete(:loop_wait) || 0.001
     @session = Net::SSH.start(host, user, options)
     @session_mutex = Mutex.new
     @port_mutex = Mutex.new
     @next_port = MAX_PORT
-    @loop_wait = options.delete(:loop_wait) || 0.001
     initiate_event_loop!
   end
 


### PR DESCRIPTION
...net::ssh start doesn't complain about loop_wait.

Currently broken in gem version 1.1.0 and net-ssh 2.3.0.

The valid options listed in net-ssh for start are: VALID_OPTIONS = [
      :auth_methods, :bind_address, :compression, :compression_level, :config, 
      :encryption, :forward_agent, :hmac, :host_key, :kex, :keys, :key_data, 
      :languages, :logger, :paranoid, :password, :port, :proxy, 
      :rekey_blocks_limit,:rekey_limit, :rekey_packet_limit, :timeout, :verbose,
      :global_known_hosts_file, :user_known_hosts_file, :host_key_alias,
      :host_name, :user, :properties, :passphrase, :keys_only
    ]